### PR TITLE
Update ModernGamertagSuffix to string? in XboxAuthXuiClaims

### DIFF
--- a/XboxAuthNet/XboxLive/Entity/XboxAuthXuiClaims.cs
+++ b/XboxAuthNet/XboxLive/Entity/XboxAuthXuiClaims.cs
@@ -12,7 +12,7 @@ namespace XboxAuthNet.XboxLive.Entity
         [JsonPropertyName("umg")]
         public string? UniqueModernGamertag { get; set; }
         [JsonPropertyName("mgs")]
-        public int ModernGamertagSuffix { get; set; }
+        public string? ModernGamertagSuffix { get; set; }
 
         [JsonPropertyName("xid")]
         public string? XboxUserId { get; set; }


### PR DESCRIPTION
I made a mistake in my previous pull request and setting up ModernGamertagSuffix to int and it cause error. I have changed to 'string?' and it works.